### PR TITLE
Add name attribute to application scope

### DIFF
--- a/client/application_scope.go
+++ b/client/application_scope.go
@@ -50,6 +50,7 @@ type CommonStruct struct {
 type Variables struct {
 	Attribute string `json:"attribute"`
 	Value     string `json:"value"`
+	Name 	  string `json:"name"`
 }
 
 // Get Application Scope

--- a/khulnasoft/data_application_scope.go
+++ b/khulnasoft/data_application_scope.go
@@ -1,8 +1,8 @@
 package khulnasoft
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/khulnasoft/terraform-provider-khulnasoft/client"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataApplicationScope() *schema.Resource {
@@ -63,6 +63,10 @@ func dataApplicationScope() *schema.Resource {
 																Type:     schema.TypeString,
 																Optional: true,
 															},
+															"name": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
 														},
 													},
 												},
@@ -90,6 +94,10 @@ func dataApplicationScope() *schema.Resource {
 																Computed: true,
 															},
 															"value": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+															"name": {
 																Type:     schema.TypeString,
 																Optional: true,
 															},
@@ -123,6 +131,10 @@ func dataApplicationScope() *schema.Resource {
 																Type:     schema.TypeString,
 																Optional: true,
 															},
+															"name": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
 														},
 													},
 												},
@@ -153,6 +165,11 @@ func dataApplicationScope() *schema.Resource {
 													Computed: true,
 												},
 												"value": {
+													Type:     schema.TypeString,
+													Optional: true,
+													Computed: true,
+												},
+												"name": {
 													Type:     schema.TypeString,
 													Optional: true,
 													Computed: true,
@@ -192,6 +209,10 @@ func dataApplicationScope() *schema.Resource {
 																Type:     schema.TypeString,
 																Optional: true,
 															},
+															"name": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
 														},
 													},
 												},
@@ -222,6 +243,10 @@ func dataApplicationScope() *schema.Resource {
 																Type:     schema.TypeString,
 																Optional: true,
 															},
+															"name": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
 														},
 													},
 												},
@@ -249,6 +274,10 @@ func dataApplicationScope() *schema.Resource {
 																Computed: true,
 															},
 															"value": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+															"name": {
 																Type:     schema.TypeString,
 																Optional: true,
 															},
@@ -290,6 +319,10 @@ func dataApplicationScope() *schema.Resource {
 																Type:     schema.TypeString,
 																Optional: true,
 															},
+															"name": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
 														},
 													},
 												},
@@ -317,6 +350,10 @@ func dataApplicationScope() *schema.Resource {
 																Computed: true,
 															},
 															"value": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+															"name": {
 																Type:     schema.TypeString,
 																Optional: true,
 															},

--- a/khulnasoft/resource_application_scope.go
+++ b/khulnasoft/resource_application_scope.go
@@ -2,10 +2,9 @@ package khulnasoft
 
 import (
 	"fmt"
-	"strings"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/khulnasoft/terraform-provider-khulnasoft/client"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"strings"
 )
 
 func resourceApplicationScope() *schema.Resource {
@@ -55,7 +54,7 @@ func resourceApplicationScope() *schema.Resource {
 									"image": {
 										Type:        schema.TypeSet,
 										Optional:    true,
-										Description: "Name of a registry as defined in Khulnasoft",
+										Description: "Name of a registry as defined in Aqua",
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"expression": {
@@ -72,6 +71,10 @@ func resourceApplicationScope() *schema.Resource {
 																Optional: true,
 															},
 															"value": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+															"name": {
 																Type:     schema.TypeString,
 																Optional: true,
 															},
@@ -104,6 +107,10 @@ func resourceApplicationScope() *schema.Resource {
 																Type:     schema.TypeString,
 																Optional: true,
 															},
+															"name": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
 														},
 													},
 												},
@@ -129,6 +136,10 @@ func resourceApplicationScope() *schema.Resource {
 																Optional: true,
 															},
 															"value": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+															"name": {
 																Type:     schema.TypeString,
 																Optional: true,
 															},
@@ -160,6 +171,10 @@ func resourceApplicationScope() *schema.Resource {
 													Computed: true,
 												},
 												"value": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"name": {
 													Type:     schema.TypeString,
 													Computed: true,
 												},
@@ -197,6 +212,10 @@ func resourceApplicationScope() *schema.Resource {
 																Type:     schema.TypeString,
 																Optional: true,
 															},
+															"name": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
 														},
 													},
 												},
@@ -225,6 +244,10 @@ func resourceApplicationScope() *schema.Resource {
 																Type:     schema.TypeString,
 																Optional: true,
 															},
+															"name": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
 														},
 													},
 												},
@@ -250,6 +273,10 @@ func resourceApplicationScope() *schema.Resource {
 																Optional: true,
 															},
 															"value": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+															"name": {
 																Type:     schema.TypeString,
 																Optional: true,
 															},
@@ -290,6 +317,10 @@ func resourceApplicationScope() *schema.Resource {
 																Type:     schema.TypeString,
 																Optional: true,
 															},
+															"name": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
 														},
 													},
 												},
@@ -315,6 +346,10 @@ func resourceApplicationScope() *schema.Resource {
 																Optional: true,
 															},
 															"value": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+															"name": {
 																Type:     schema.TypeString,
 																Optional: true,
 															},
@@ -558,6 +593,7 @@ func createCommonStruct(m map[string]interface{}) client.CommonStruct {
 		Vars = append(Vars, client.Variables{
 			Attribute: v["attribute"].(string),
 			Value:     v["value"].(string),
+			Name:      v["name"].(string),
 		})
 	}
 	commonStruct.Expression = Expresion
@@ -687,6 +723,7 @@ func flattenAppScopeVariables(variables []client.Variables) []interface{} {
 		check[i] = map[string]interface{}{
 			"attribute": variables[i].Attribute,
 			"value":     variables[i].Value,
+			"name":      variables[i].Name,
 		}
 	}
 

--- a/khulnasoft/resource_application_scope_test.go
+++ b/khulnasoft/resource_application_scope_test.go
@@ -41,14 +41,19 @@ func testAccCheckApplicationScope(name string, description string) string {
 		categories {
 			artifacts {
 				image {
-					expression = "v1 && v2"
+					expression = "v1 && v2 && v3"
 					variables {
-						attribute = "khulnasoft.registry"
+						attribute = "aqua.registry"
 						value = "test"
 					}
 					variables {
 						attribute = "image.repo"
 						value = "test123"
+					}
+					variables {
+						attribute = "image.label"
+						name = "test.label"
+						value = "test.value.123"
 					}
 				}
 			}


### PR DESCRIPTION
### **User description**
**Notes for Reviewers**

This PR fixes #




**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [*] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


___

### **PR Type**
enhancement


___

### **Description**
- Added a new `name` attribute to the application scope schema in multiple places, making it optional and in some cases computed.
- Improved code organization by rearranging import statements.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>data_application_scope.go</strong><dd><code>Add optional `name` attribute to application scope schema</code></dd></summary>
<hr>

khulnasoft/data_application_scope.go

<li>Added <code>name</code> attribute to multiple schema configurations.<br> <li> Ensured <code>name</code> attribute is optional and sometimes computed.<br> <li> Reorganized import statements for clarity.<br>


</details>


  </td>
  <td><a href="https://github.com/khulnasoft/terraform-provider-khulnasoft/pull/6/files#diff-624d592c3f8a229c0ae9b1a5abcf922f13f1578a29c5176d82f21ef0225b5bba">+38/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information

## Summary by Sourcery

New Features:
- Add a 'name' attribute to the application scope schema, allowing users to optionally specify a name for various elements within the application scope.