### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/client/runtime_policy.go
+++ b/client/runtime_policy.go
@@ -308,7 +308,14 @@ func (cli *Client) CreateRuntimePolicy(runtimePolicy *RuntimePolicy) error {
 	if err != nil {
 		return err
 	}
-	log.Println(string(payload))
+	// Create a copy of the payload with sensitive information removed
+	var sanitizedPayload map[string]interface{}
+	json.Unmarshal(payload, &sanitizedPayload)
+	if tripwire, ok := sanitizedPayload["tripwire"].(map[string]interface{}); ok {
+		tripwire["user_password"] = "REDACTED"
+	}
+	sanitatedPayloadBytes, _ := json.Marshal(sanitizedPayload)
+	log.Println(string(sanitatedPayloadBytes))
 	resp, body, errs := request.Clone().Set("Authorization", "Bearer "+cli.token).Post(cli.url + apiPath).Send(string(payload)).End()
 	if errs != nil {
 		return errors.Wrap(getMergedError(errs), "failed creating runtime policy.")


### PR DESCRIPTION
Potential fix for [https://github.com/khulnasoft/terraform-provider-khulnasoft/security/code-scanning/2](https://github.com/khulnasoft/terraform-provider-khulnasoft/security/code-scanning/2)

To fix the problem, we need to ensure that sensitive information is not logged in clear text. The best way to fix this is to remove the sensitive information from the payload before logging it. This can be done by creating a copy of the payload with the sensitive fields removed or masked before logging.

1. Identify the sensitive fields in the `RuntimePolicy` struct.
2. Create a copy of the payload with the sensitive fields removed or masked.
3. Log the modified payload instead of the original payload.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
